### PR TITLE
Correct Download Link in the README file

### DIFF
--- a/README
+++ b/README
@@ -3,7 +3,7 @@ WARNING: This is an incomplete ("beta") version of SableCC 4. It is
 targeted to users that want to test the new features of SableCC 4.
 If you are are looking for a stable SableCC version, please visit:
 
-    http://sablecc.org/wiki/DownloadPage
+    https://sablecc.org/downloads
 ----------------------------------------------------------------------
 
 Welcome to SableCC 4!


### PR DESCRIPTION
The former link pointed to a 404 error page. This new one sends you to the right Downloads page